### PR TITLE
better URL scheme preview

### DIFF
--- a/src/gemini.rs
+++ b/src/gemini.rs
@@ -59,10 +59,12 @@ impl GeminiLine {
                 }
             }
             let prefix = match parsed_url.scheme() {
-                "https" | "http" => "[WWW]",
-                "gemini" => "[GEM]",
-                "gopher" => "[GPH]",
-                _ => "[UKN]",
+                "https" | "http" => "[WWW]".to_string(),
+                "gemini" => "[GEM]".to_string(),
+                "gopher" => "[GPH]".to_string(),
+                "mailto" => "[ \u{2709} ]".to_string(),
+                // show first three letters of scheme, lower case to differentiate
+                other => format!("[{}]",other.chars().take(3).collect::<String>()),
             };
             return Ok(GeminiLine {
                 line_type: LineType::Link,


### PR DESCRIPTION
Instead of showing `[UNK]` for all unknown schemes, instead show the first three letters of the scheme, in lower case to differentiate.