### PR TITLE
better gemini status code parsing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 ** [unreleased]
   New features:
   - Setting for automatic text wrapping of gemini content
+  - Unknown success status codes are now handled gracefully, displaying any content.
 
   Bugfixes:
   - Use download path from setting for downloading files

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -472,6 +472,7 @@ impl Controller {
                                     if check(buf.chars().nth(1)) {
                                         // If mimetype is text/* download as gemini
                                         // Otherwise initiate a binary download
+                                        // FIXME: for now assumes all text is gemini text
                                         if meta.starts_with("text/") {
                                             let mut buf = vec![];
                                             bufr.read_to_end(&mut buf).unwrap_or_else(|err| {

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -2,7 +2,6 @@ use chrono::Local;
 use chrono::{Duration, Utc};
 use cursive::Cursive;
 use lazy_static::lazy_static;
-use regex::Regex;
 use sha2::{Digest, Sha256};
 use std::error::Error;
 use std::fs::File;
@@ -17,7 +16,7 @@ use url::Url;
 
 use crate::bookmarks::{Bookmark, Bookmarks};
 use crate::certificates::{Certificate, Certificates};
-use crate::gemini::{GeminiType};
+use crate::gemini::GeminiType;
 use crate::gophermap::{GopherMapEntry, ItemType};
 use crate::history::{History, HistoryEntry};
 use crate::ncgopher::{NcGopher, UiMessage};
@@ -195,7 +194,7 @@ impl Controller {
         }
 
         let server_details = Controller::get_host_from_url(&url);
-        
+
         let _server: Vec<_>;
         match server_details.as_str().to_socket_addrs() {
             Ok(s) => {
@@ -396,29 +395,85 @@ impl Controller {
                                     .unwrap();
                                 return;
                             }
-                            match buf.chars().next().unwrap() {
-                                '1' => {
-                                    let status1 = Regex::new(r"^10\s+(.*)$").unwrap();
-                                    if let Some(caps) = status1.captures(&buf) {
-                                        let query = caps.get(1).unwrap().as_str();
-                                        info!("Got query: {}", query);
-                                        tx_clone
-                                            .send(ControllerMessage::RequestGeminiQueryDialog(
-                                                url,
-                                                query.to_string(),
-                                            ))
-                                            .unwrap();
+
+                            // <META> always starts at the 4th char
+                            // (it might contain leading whitespace)
+                            let meta = buf.chars().skip(3).collect::<String>();
+                            // check maximum size of <META>
+                            if meta.len() > 1024 {
+                                tx_clone
+                                    .send(ControllerMessage::ShowMessage(
+                                        "invalid header from server: <META> too large".to_string(),
+                                    ))
+                                    .unwrap();
+                            }
+
+                            // A function to check the second digit of a status code in the default
+                            // branch. I.e. the second digit should be zero.
+                            //
+                            // Returns false if the status code is invalid and thus the response
+                            // header is invalid.
+                            let check = |other: Option<char>| -> bool {
+                                if other == Some('0') {
+                                    // ok
+                                } else if matches!(other, Some(c) if c.is_ascii_digit()) {
+                                    // the second char is an ASCII digit, but this code is not handled
+                                    tx_clone
+                                        .send(ControllerMessage::ShowMessage(format!(
+                                            "unknown status code {}",
+                                            buf.chars().take(2).collect::<String>(),
+                                        )))
+                                        .unwrap();
+                                } else {
+                                    // either the second char is not an ASCII digit
+                                    // or does not exist at all
+                                    tx_clone
+                                        .send(ControllerMessage::ShowMessage(format!(
+                                            "invalid header from server: invalid status code: {}",
+                                            buf
+                                        )))
+                                        .unwrap();
+                                    // the header is already invalid, no need to check further
+                                    return false;
+                                }
+                                // after the two digit status code there should be a space
+                                // otherwhise the header is invalid too
+                                buf.chars().nth(2) == Some(' ')
+                            };
+
+                            match buf.chars().next() {
+                                Some('1') => {
+                                    // INPUT
+                                    match buf.chars().nth(1) {
+                                        Some('1') => {
+                                            // TODO: Handle password inputs
+                                        }
+                                        other => {
+                                            if check(other) {
+                                                info!("Got query: {}", meta);
+                                                tx_clone
+                                                    .send(
+                                                        ControllerMessage::RequestGeminiQueryDialog(
+                                                            url, meta,
+                                                        ),
+                                                    )
+                                                    .unwrap();
+                                            }
+                                            tx_clone
+                                                .send(ControllerMessage::RedrawHistory)
+                                                .unwrap();
+                                        }
                                     }
-                                    // TODO: Handle password inputs
                                     return;
                                 }
-                                '2' => {
-                                    let status2 = Regex::new(r"^(2[01])\s+(.*);?").unwrap();
-                                    if let Some(caps) = status2.captures(&buf) {
-                                        let mimetype = caps.get(2).unwrap().as_str();
+                                Some('2') => {
+                                    // SUCCESS
+                                    // there are not yet any other status codes
+                                    // than 20 in this category
+                                    if check(buf.chars().nth(1)) {
                                         // If mimetype is text/* download as gemini
                                         // Otherwise initiate a binary download
-                                        if mimetype.starts_with("text/") {
+                                        if meta.starts_with("text/") {
                                             let mut buf = vec![];
                                             bufr.read_to_end(&mut buf).unwrap_or_else(|err| {
                                                 tx_clone
@@ -449,13 +504,12 @@ impl Controller {
                                                 .unwrap();
                                         } else {
                                             // Binary download
-                                            let f = File::create(local_filename.clone())
-                                                .unwrap_or_else(|_| {
-                                                    panic!(
-                                                        "Unable to open file '{}'",
-                                                        local_filename.clone()
-                                                    )
-                                                });
+                                            let f = File::create(local_filename.clone()).expect(
+                                                &format!(
+                                                    "Unable to open file '{}'",
+                                                    local_filename.clone()
+                                                ),
+                                            );
                                             let mut bw = BufWriter::new(f);
                                             let mut buf = [0u8; 1024];
                                             let mut total_written: usize = 0;
@@ -484,64 +538,53 @@ impl Controller {
                                                 ))
                                                 .unwrap();
                                         }
-                                    } else {
-                                        tx_clone
-                                            .send(ControllerMessage::ShowMessage(format!(
-                                                "Invalid status code: {}",
-                                                buf
-                                            )))
-                                            .unwrap();
                                     }
                                 }
-                                '3' => {
-                                    let status3 = Regex::new(r"^(3[01])\s+(.*)\s*$?").unwrap();
-                                    if let Some(caps) = status3.captures(&buf) {
-                                        // TODO: Should automatically update bookmarks when code is 31
-                                        let _code = caps.get(1).unwrap().as_str();
-                                        let url = caps.get(2).unwrap().as_str();
-                                        // FIXME: Try to parse url, check scheme
-                                        if let Ok(url) = Url::parse(url) {
-                                            tx_clone
-                                                .send(ControllerMessage::FetchGeminiUrl(
-                                                    url, true, 0,
-                                                ))
-                                                .unwrap();
-                                        } else {
-                                            tx_clone
-                                                .send(ControllerMessage::ShowMessage(format!(
-                                                    "Invalid redirect url: {}",
-                                                    url
-                                                )))
-                                                .unwrap();
+                                Some('3') => {
+                                    // REDIRECT
+                                    let other = buf.chars().nth(1);
+                                    if other == Some('1') {
+                                        // redirect is permanent
+                                        // TODO: Should automatically update bookmarks
+                                    }
+                                    if check(other) {
+                                        match Url::parse(&meta) {
+                                            Ok(_url) => {
+                                                // FIXME: Try to parse url, check scheme
+                                            }
+                                            Err(_) => {
+                                                tx_clone
+                                                    .send(ControllerMessage::ShowMessage(format!(
+                                                        "invalid redirect url: {}",
+                                                        meta
+                                                    )))
+                                                    .unwrap();
+                                            }
                                         }
-                                    } else {
+                                    }
+                                    return;
+                                }
+                                Some('4') // FAILURE
+                                | Some('5') // PERMANENT FAILURE
+                                | Some('6') // CLIENT CERTIFICATE
+                                => {
+                                    if check(buf.chars().nth(1)) {
                                         tx_clone
                                             .send(ControllerMessage::ShowMessage(format!(
-                                                "Invalid header from server: {}",
+                                                "Gemini error: {}",
                                                 buf
                                             )))
                                             .unwrap();
                                     }
                                     return;
                                 }
-                                '4' | '5' | '6' => {
-                                    let _status4 = Regex::new(r"^(4[01234])\s+(.*)\s+$?").unwrap();
-                                    let _status5 = Regex::new(r"^(5[01239])\s+(.*)\s+$?").unwrap();
-                                    let _status6 = Regex::new(r"^(6[012345])\s+(.*)\s+$?").unwrap();
+                                other => {
                                     tx_clone
-                                        .send(ControllerMessage::ShowMessage(format!(
-                                            "Gemini error: {}",
-                                            buf
-                                        )))
-                                        .unwrap();
-                                    return;
-                                }
-                                _ => {
-                                    tx_clone
-                                        .send(ControllerMessage::ShowMessage(format!(
-                                            "Unhandled status code: {}",
-                                            buf
-                                        )))
+                                        .send(ControllerMessage::ShowMessage(if other.is_some() {
+                                            format!("invalid header from server: invalid status code: {}", buf)
+                                        } else {
+                                            format!("invalid header from server: missing status code: {}", buf)
+                                        }))
                                         .unwrap();
                                     return;
                                 }
@@ -765,10 +808,9 @@ impl Controller {
             let mut total_written: usize = 0;
             if port != 70 {
                 if let Ok(connector) = TlsConnector::new() {
-                    let stream =
-                        TcpStream::connect(server_details.clone()).unwrap_or_else(|_| {
-                            panic!("Couldn't connect to the server {}", server_details)
-                        });
+                    let stream = TcpStream::connect(server_details.clone()).unwrap_or_else(|_| {
+                        panic!("Couldn't connect to the server {}", server_details)
+                    });
                     match connector.connect(&server, stream) {
                         Ok(mut stream) => {
                             tls = true;


### PR DESCRIPTION
Handle unknown gemini status codes gracefully according to their general category (first digit). The changed parsing method does not depend on regex any more.

Also checks the restrictions on the `<META>` part of the response header from the specification (max. length 1024 bytes).