### PR TITLE
gemini refactoring, workaround

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 
   Bugfixes:
   - Use download path from setting for downloading files
+  - Fix error 59 "invalid url" from gemini://drewdevault.com, SNI is enabled
 
 ** 0.1.5
   New features:

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -348,7 +348,7 @@ impl Controller {
 
             // Handshake done, request URL from gemini server
             info!("Writing url '{}'", url.as_str());
-            write!(stream, "{}\r\n", url.as_str()).unwrap();
+            stream.write_all(format!("{}\r\n", url).as_bytes()).unwrap();
 
             let mut bufr = BufReader::new(stream);
             info!("Reading from gemini stream");


### PR DESCRIPTION
This is mostly some refactoring to have less rightward drift in `fetch_gemini_url`. There is also a small "bugfix" thrown in:
When I was testing if TLS SNI was working <sup>[why?](https://lists.orbitalfox.eu/archives/gemini/2020/003160.html)</sup>, I discovered that gemini://drewdevault.com often returned a 59 status code and `Protocol error: invalid url`, and only worked randomly.
Using `stream.write_all` instead of `write!(stream, ...)` seems to fix this. I tried to find out what the difference is, but had no luck. It could also be just a problem on the server side, but in that case consider it a workaround.