### PR TITLE
implement debug log to file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,5 @@ base64 = "0.12.3"
 
 [dependencies.cursive]
 version = "0.15.0"
-#git = "https://github.com/gyscos/cursive"
 default-features = false
 features = ["pancurses-backend", "toml"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ url = "2.1.1"
 chrono = "0.4.15"
 lazy_static = "1.4.0"
 clap = "2.33.3"
-log = "0.4.11"
+log = { version = "0.4.11", features = ["std"] }
 dirs = "3.0.1"
 config = "0.10.1"
 serde_derive = "1.0.115"

--- a/src/certificates.rs
+++ b/src/certificates.rs
@@ -4,7 +4,6 @@ use std::fs::File as FsFile;
 use std::io::Write;
 use std::path::Path;
 
-
 /// Manages server certificates for use in TOFU for the gemini protocol.
 /// This could be modelled as a hashmap instead of a vector with structs,
 /// but we might later extend the list with ip-address and cypher type.

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,5 +1,4 @@
-use chrono::Local;
-use chrono::{Duration, Utc};
+use chrono::{Duration, Local, Utc};
 use cursive::Cursive;
 use lazy_static::lazy_static;
 use sha2::{Digest, Sha256};

--- a/src/ncgopher.rs
+++ b/src/ncgopher.rs
@@ -138,7 +138,6 @@ impl NcGopher {
 
     /// Setup of UI, register global keys
     pub fn setup_ui(&mut self) {
-        cursive::logger::init();
         info!("NcGopher::setup_ui()");
         self.create_menubar();
         let mut app = self.app.write().unwrap();
@@ -320,8 +319,6 @@ impl NcGopher {
             .view("gemini_content", gemini_event_view, "Gemini");
         layout.set_view("content");
         app.add_fullscreen_layer(layout.with_name("main"));
-
-        app.add_global_callback('~', Cursive::toggle_debug_console);
     }
 
     // TODO: Should be moved to controller

--- a/src/ncgopher.rs
+++ b/src/ncgopher.rs
@@ -815,7 +815,8 @@ impl NcGopher {
             |s: &mut ScrollView<ResizedView<NamedView<SelectView<GeminiLine>>>>| {
                 s.content_viewport().width()
             },
-        ).unwrap_or(0)
+        )
+        .unwrap_or(0)
     }
 
     /// Renders a gemini site in a cursive::TextView
@@ -1518,9 +1519,9 @@ impl NcGopher {
         let mut app = self.app.write().expect("Could not get read lock on app");
         if let Some(content) = app.find_name::<SelectView<GopherMapEntry>>("content") {
             content.selected_id()
-        }else if let Some(content) = app.find_name::<SelectView<GeminiLine>>("gemini_content") {
+        } else if let Some(content) = app.find_name::<SelectView<GeminiLine>>("gemini_content") {
             content.selected_id()
-        }else{
+        } else {
             panic!("view content and gemini_content missing");
         }
     }


### PR DESCRIPTION
This implements the debug log to file that was already shown in the help text. But as a consequence, because only one logger can be active at a time, this removes the debug console inside cursive and the respective "hidden" keybinding.