### PR TITLE
fix internationalized domain handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,12 +73,6 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
-
-[[package]]
-name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
@@ -88,6 +82,18 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "bitvec"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ba35e9565969edb811639dbebfe34edc0368e472c5018474c8eb2543397f81"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "blake2b_simd"
@@ -162,7 +168,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b076e143e1d9538dde65da30f8481c2a6c44040edb8e02b9bf1351edb92ce3"
 dependencies = [
  "lazy_static",
- "nom",
+ "nom 5.1.2",
  "rust-ini",
  "serde 1.0.118",
  "serde-hjson",
@@ -347,11 +353,11 @@ checksum = "993a608597367c6377b258c25d7120740f00ed23a2252b729b1932dd7866f908"
 
 [[package]]
 name = "der-oid-macro"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e66558629d772c3be040566b7be07be8c8f5aecee95e4a092dfe2efc313277ad"
+checksum = "bd17d13ecf875e704369fdbde242483ac769fc18f6af21e43d5a692a079732fc"
 dependencies = [
- "nom",
+ "nom 6.0.1",
  "num-bigint",
  "num-traits 0.2.14",
  "proc-macro-hack",
@@ -359,12 +365,12 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
-version = "4.1.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caca07c50eaae94d43e21f4d14eca5543b6f5f5ce64715e9b7665ac5f5185b4e"
+checksum = "cb4b1e27396f46037881c39d821660f2ff48797aaa7152a45ded7a93b368a819"
 dependencies = [
  "der-oid-macro",
- "nom",
+ "nom 6.0.1",
  "num-bigint",
  "num-traits 0.2.14",
  "proc-macro-hack",
@@ -487,6 +493,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+
+[[package]]
 name = "gemtext"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,6 +534,24 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+dependencies = [
+ "ahash 0.4.7",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d99cf782f0dc4372d26846bec3de7804ceb5df083c2d4462c0b8d2330e894fa8"
+dependencies = [
+ "hashbrown",
 ]
 
 [[package]]
@@ -583,9 +613,9 @@ checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.18.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e704a02bcaecd4a08b93a23f6be59d0bd79cd161e0963e9499165a0a35df7bd"
+checksum = "64d31059f22935e6c31830db5249ba2b7ecd54fd73a9909286f0a67aa55c2fbd"
 dependencies = [
  "pkg-config",
  "vcpkg",
@@ -609,20 +639,11 @@ checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
 dependencies = [
  "cfg-if 0.1.10",
-]
-
-[[package]]
-name = "lru-cache"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-dependencies = [
- "linked-hash-map 0.5.3",
 ]
 
 [[package]]
@@ -651,9 +672,9 @@ checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "native-tls"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fcc7939b5edc4e4f86b1b4a04bb1498afaaf871b1a6691838ed06fcb48d3a3f"
+checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
 dependencies = [
  "lazy_static",
  "libc",
@@ -671,17 +692,19 @@ dependencies = [
 name = "ncgopher"
 version = "0.1.5"
 dependencies = [
- "base64 0.12.3",
+ "base64",
  "chrono",
  "clap",
  "config",
  "cursive",
  "dirs",
  "gemtext",
+ "idna",
  "lazy_static",
  "log",
  "native-tls",
  "pancurses",
+ "percent-encoding",
  "rusqlite",
  "serde 1.0.118",
  "serde_derive",
@@ -709,6 +732,18 @@ version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
+ "lexical-core",
+ "memchr",
+ "version_check",
+]
+
+[[package]]
+name = "nom"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88034cfd6b4a0d54dd14f4a507eceee36c0b70e5a02236c4e4df571102be17f0"
+dependencies = [
+ "bitvec",
  "lexical-core",
  "memchr",
  "version_check",
@@ -795,6 +830,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2508c8f170e55be68508b1113956a760a82684f42022f8834fb16ca198621211"
+dependencies = [
+ "der-parser",
 ]
 
 [[package]]
@@ -911,6 +955,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
+
+[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,19 +1047,18 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.23.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45d0fd62e1df63d254714e6cb40d0a0e82e7a1623e7a27f679d851af092ae58b"
+checksum = "d5f38ee71cbab2c827ec0ac24e76f82eca723cee92c509a65f67dee393c25112"
 dependencies = [
  "bitflags",
  "chrono",
  "fallible-iterator",
  "fallible-streaming-iterator",
+ "hashlink",
  "libsqlite3-sys",
- "lru-cache",
  "memchr",
  "smallvec",
- "time",
  "url",
 ]
 
@@ -1019,7 +1068,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "blake2b_simd",
  "constant_time_eq",
  "crossbeam-utils 0.8.1",
@@ -1033,11 +1082,11 @@ checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
 
 [[package]]
 name = "rusticata-macros"
-version = "2.1.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a9050636e8a1b487ba1fbe99114021cd7594dde3ce6ed95bfc1691e5b5367b"
+checksum = "7390af60e66c44130b4c5ea85f2555b7ace835d73b4b889c704dc3cb4c0468c8"
 dependencies = [
- "nom",
+ "nom 6.0.1",
 ]
 
 [[package]]
@@ -1216,6 +1265,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36474e732d1affd3a6ed582781b3683df3d0563714c59c39591e8ff707cf078e"
 
 [[package]]
 name = "tempfile"
@@ -1439,19 +1494,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "x509-parser"
-version = "0.8.2"
+name = "wyz"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76245c48460d72a3e17ad3a01855c3cae98601bb992091c1c1421c77d1cb27c"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+
+[[package]]
+name = "x509-parser"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b22c80f083d860f8e77f44762e9df8c92de7defeb70219ec37f32968cab53e90"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "chrono",
  "data-encoding",
  "der-oid-macro",
  "der-parser",
  "lazy_static",
- "nom",
+ "nom 6.0.1",
  "num-bigint",
+ "oid-registry",
  "rusticata-macros",
  "rustversion",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,28 +18,23 @@ repository = "jansc/ncgopher"
 
 [dependencies]
 unicode-width = "0.1.8"
-url = "2.1.1"
-chrono = "0.4.15"
+url = "2.2"
+chrono = "0.4.19"
 lazy_static = "1.4.0"
 clap = "2.33.3"
-log = { version = "0.4.11", features = ["std"] }
+log = { version = "0.4.13", features = ["std"] }
 dirs = "3.0.1"
 config = "0.10.1"
-serde_derive = "1.0.115"
-serde = { version = "1.0.115", features = ["derive"] }
-sha2 = "0.9.1"
-toml = "0.5.6"
-rusqlite = { version = "0.23.1", features = ["url", "chrono"] }
+serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+sha2 = "0.9.2"
+toml = "0.5.8"
+rusqlite = { version = "0.24.2", features = ["url", "chrono"] }
 gemtext = "0.2.1"
-
-native-tls = "0.2.4"
-x509-parser = "0.8.0-beta4"
+native-tls = "0.2.7"
+x509-parser = "0.9.0"
 pancurses = "0.16.1"
-base64 = "0.12.3"
-
-[dependencies.cursive]
-version = "0.15.0"
-default-features = false
-features = ["pancurses-backend", "toml"]
+base64 = "0.13"
 percent-encoding = "2.1"
 idna = "0.2"
+cursive = { version = "0.15", default-features = false, features = ["pancurses-backend", "toml"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,5 @@ base64 = "0.12.3"
 version = "0.15.0"
 default-features = false
 features = ["pancurses-backend", "toml"]
+percent-encoding = "2.1"
+idna = "0.2"

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -21,7 +21,7 @@ use crate::history::{History, HistoryEntry};
 use crate::ncgopher::{NcGopher, UiMessage};
 use crate::SETTINGS;
 use native_tls::{Protocol, TlsConnector};
-use x509_parser::parse_x509_der;
+use x509_parser::prelude::*;
 
 lazy_static! {
     // Gobal to keep track of the latest request. When the user
@@ -306,7 +306,7 @@ impl Controller {
                 }
 
                 // Check certificate expiration date
-                match parse_x509_der(&cert.to_der().unwrap()) {
+                match parse_x509_certificate(&cert.to_der().unwrap()) {
                     Ok((_rem, cert)) => {
                         info!("Successfully parsed certificate");
                         match cert.tbs_certificate.validity.time_to_expiration() {

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1441,9 +1441,6 @@ impl Controller {
     }
 }
 
-extern crate idna;
-extern crate percent_encoding;
-
 fn make_domain_idna(u: &mut Url) {
     use idna::domain_to_ascii;
     use percent_encoding::percent_decode_str;

--- a/src/gemini.rs
+++ b/src/gemini.rs
@@ -50,6 +50,8 @@ pub fn parse(text: &str, base_url: &Url, viewport_width: usize) -> Vec<(String, 
                         .collect()
                 }
                 Node::Link { to, name } => {
+                    use crate::ncgopher::human_readable_url;
+
                     let url = base_url.join(&to).expect("could not parse link url");
                     let prefix = match url.scheme() {
                         "https" | "http" => "[WWW]".to_string(),
@@ -60,7 +62,10 @@ pub fn parse(text: &str, base_url: &Url, viewport_width: usize) -> Vec<(String, 
                         other => format!("[{}]", other.chars().take(3).collect::<String>()),
                     };
 
-                    let name = name.unwrap_or_else(|| url.to_string());
+                    // transform the URL into a human redable form
+                    // escaping (by parsing as a URL) and unescaping is necessary because
+                    // the URL might have been escaped by the author
+                    let name = name.unwrap_or_else(|| human_readable_url(&url));
                     continuation_lines(&prefix, &name, Some(url))
                 }
                 Node::Heading { level, body } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,8 @@ extern crate log;
 extern crate base64;
 extern crate config;
 extern crate dirs;
+extern crate idna;
+extern crate percent_encoding;
 extern crate rusqlite;
 extern crate serde;
 extern crate serde_derive;

--- a/src/ncgopher.rs
+++ b/src/ncgopher.rs
@@ -622,7 +622,15 @@ impl NcGopher {
             .write()
             .expect("could not get write lock on app")
             .call_on_name("main", |v: &mut ui::layout::Layout| {
-                v.set_title(v.get_current_view(), url.to_string())
+                // format URL to human readable form
+                // since for gemini and gopher, the domains will be percent encoded like the path,
+                // it is easiest to do it all at once
+                let human_readable = percent_encoding::percent_decode_str(url.as_str())
+                    .decode_utf8()
+                    .unwrap()
+                    .to_string();
+
+                v.set_title(v.get_current_view(), human_readable)
             });
     }
 

--- a/src/ncgopher.rs
+++ b/src/ncgopher.rs
@@ -622,15 +622,7 @@ impl NcGopher {
             .write()
             .expect("could not get write lock on app")
             .call_on_name("main", |v: &mut ui::layout::Layout| {
-                // format URL to human readable form
-                // since for gemini and gopher, the domains will be percent encoded like the path,
-                // it is easiest to do it all at once
-                let human_readable = percent_encoding::percent_decode_str(url.as_str())
-                    .decode_utf8()
-                    .unwrap()
-                    .to_string();
-
-                v.set_title(v.get_current_view(), human_readable)
+                v.set_title(v.get_current_view(), human_readable_url(&url))
             });
     }
 
@@ -2028,5 +2020,41 @@ impl NcGopher {
         app.step();
 
         true
+    }
+}
+
+/// Transforms a URL back into its human readable Unicode representation.
+pub fn human_readable_url(url: &Url) -> String {
+    match url.scheme() {
+        // these schemes are considered "special" by the WHATWG spec
+        // cf. https://url.spec.whatwg.org/#special-scheme
+        "ftp" | "http" | "https" | "ws" | "wss" => {
+            // first unescape the domain name from IDNA encoding
+            let url_str = if let Some(domain) = url.domain() {
+                let (domain, result) = idna::domain_to_unicode(domain);
+                result.expect("could not decode idna domain");
+                let url_str = url.to_string();
+                // replace the IDNA encoded domain with the unescaped version
+                // since the domain cannot contain percent signs we do not have
+                // to worry about double unescaping later
+                url_str.replace(url.host_str().unwrap(), &domain)
+            } else {
+                // must be using IP address
+                url.to_string()
+            };
+            // now unescape the rest of the URL
+            percent_encoding::percent_decode_str(&url_str)
+                .decode_utf8()
+                .unwrap()
+                .to_string()
+        }
+        _ => {
+            // the domain and the path will be percent encoded
+            // it is easiest to do it all at once
+            percent_encoding::percent_decode_str(url.as_str())
+                .decode_utf8()
+                .unwrap()
+                .to_string()
+        }
     }
 }


### PR DESCRIPTION
Gemini requests now use IDNA encoded URLs. Because the gemini and gopher URL schemes are considered "non-special" by the WHATWG URL specification, which is what the Rust `url` crate implements, domain names were incorrectly percent-encoded.

While I was at it also updated all dependencies where I could find newer versions, necessitating a small change due to the deprecation of `parse_x509_der`.

I hope you do not come across the same issue as me when building, but there seems to be a small problem with the `enumset_derive` crate that seems to only happen if crates are built in a particular order. Maybe you have to retry a few times, but at some point you should be successful (at least I was).