### PR TITLE
add about scheme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+*.swp

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,10 +5,19 @@
   - Setting for automatic text wrapping of gemini content
   - Unknown success status codes are now handled gracefully, displaying any content.
   - Full text/gemini support
+  - `about` scheme and internal help pages
+  - current URL is displayed at the top
 
   Bugfixes:
   - Use download path from setting for downloading files
-  - Fix error 59 "invalid url" from gemini://drewdevault.com, SNI is enabled
+  - Fix Gemini error 59 "invalid url" from gemini://drewdevault.com, SNI is enabled
+  - correctly handle international domain names for Gemini
+  - actually update certificate fingerprints for Gemini
+  - correctly set the current URL when a Gemini request fails so the r key can be
+    used for retrying
+
+  Changes:
+  - Search menu items removed in favour of internal help pages
 
 ** 0.1.5
   New features:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 `ncgopher` is a gopher and gemini client for the modern internet. It uses
 ncurses and is written in Rust.
 
-
 ## gopher
 
 Gopher was developed in 1991 at the University of Minnesota, and named
@@ -11,13 +10,11 @@ after the school's mascot. Gopher is a menu-driven interface that
 allows a user to browse for text information served off of various
 gopher servers.
 
-
 ## gemini
 
 Gemini is a new application-level internet protocol for the distribution
 of arbitrary files, with some special consideration for serving a
 lightweight hypertext format which facilitates linking between files.
-
 
 ## Screenshot
 
@@ -26,7 +23,6 @@ Obligatory screenshot:
 ![img](./screenshots/ncgopher.png "Screenshot of NcGopher")
 
 ![img](./screenshots/ncgopher-darkmode.png "Screenshot of NcGopher")
-
 
 ## Features
 
@@ -43,7 +39,6 @@ Obligatory screenshot:
 -   Darkmode!
 -   Common search providers in search menu for quick access
 -   External commands for HTML, images and Telnet
-
 
 ## Installation
 
@@ -77,7 +72,6 @@ To install the latest development version:
     cargo build
     cargo run
 
-
 ## Key bindings
 
 During alpha, the keybindings are not configurable and many operations
@@ -109,16 +103,16 @@ are still not implemented.
 If you want to select text, most terminal support selection while 
 pressing `SHIFT`.
 
-
 ## Debugging
 
 The software is still in beta, and it is also my first application
 written in Rust. Expect lots of bugs and badly written Rust code.
 
-If the application crashes, I'd be interested in a backtrace. Start
-the application with `RUST_BACKTRACE=1 cargo run`.  There is also a
-debug view that can be activated with the `~`-key.
-
+If the application crashes, I'd be interested in a backtrace and/or a log file.
+Start the application with `RUST_BACKTRACE=1 cargo run -d error.log`.
+This will append log messages to `error.log` (the file will be created if it
+does not exist) and output a backtrace when the program crashes.
+With this, try to reproduce the bug and take note of the backtrace output.
 
 ## License
 
@@ -126,4 +120,3 @@ debug view that can be activated with the `~`-key.
 
 Copyright (c) 2020, Jan Schreiber. Parts of the status bar
 implementation are Copyright (c) 2019, Henrik Friedrichsen
-

--- a/src/about/help.gmi
+++ b/src/about/help.gmi
@@ -26,6 +26,8 @@ Welcome to ncgopher, a ncurses client for gemini and gopher. You can use the fol
 # What is this?
 ncgopher is a browser for the gemini and the gopher protocols, sometimes also collectively known as the "small internet".
 
+=> about:sites See some pages to start of from.
+
 ## Gopher
 Gopher was deveolped in 1991 at the University of Minnesota, and named after the school's mascot. Gopher is a menu-driven interface that allows a user to browse for text information served off of various gopher servers.
 => gopher://gopherpedia.com:70/1/about some information about gopher (and gopherpedia) at gopherpedia, a Wikipedia mirror for the gohper protocol
@@ -36,6 +38,7 @@ Gemini is a new application-level internet protocol for the distribution of arbi
 And actually, the document you are seeing here is written in Gemini's text format. You can take a look at this page in the sources in src/about/help.gmi !
 
 ## What do you mean "sources"?
-ncgopher is free (libre) and open source software licensed under the "2-clause BSD" or "FreeBSD" license. The FreeBSD license is classified by the Free Software Foundation as a "free software license". The source code is versioned in a git repository available through GitHub. It is written in the Rust programming language.
+ncgopher is free (libre) and open source software licensed under the "2-clause BSD" or "FreeBSD" license.  It is written in the Rust programming language. The source code is versioned in a git repository available through GitHub:
 => https://github.com/jansc/ncgopher
-Copyright © 2020, Jan Schreiber. Parts of the status bar implementation are Copyright © 2019, Henrik Friedrichsen.
+If you have any issues or feel something important is missing, you can raise that as an issue there. Or feel free to contribute there as well!
+Copyright © 2020, Jan Schreiber <jan@mecinus.com>. Parts of the status bar implementation are Copyright © 2019, Henrik Friedrichsen.

--- a/src/about/help.gmi
+++ b/src/about/help.gmi
@@ -1,0 +1,41 @@
+# Welcome
+Welcome to ncgopher, a ncurses client for gemini and gopher. You can use the following key commands:
+
+```
+|------------+--------------------------------|
+| Key        | Command                        |
+|------------+--------------------------------|
+| Arrow keys | Move around in text            |
+| j/k        | Move around in text (like vi)  |
+| Enter      | Open the link under the cursor |
+| Esc        | Go to menubar                  |
+| Space      | Scroll down one page           |
+| g          | Open new URL                   |
+| b          | Navigate back                  |
+| q          | Close application              |
+| s          | Save current page              |
+| r          | Reload current page            |
+| i          | Show link under cursor         |
+| n          | Go to next link                |
+| p          | Go to previous link            |
+| a          | Add bookmark for current page  |
+| ?          | Display the key map again      |
+|------------+--------------------------------|
+```
+
+# What is this?
+ncgopher is a browser for the gemini and the gopher protocols, sometimes also collectively known as the "small internet".
+
+## Gopher
+Gopher was deveolped in 1991 at the University of Minnesota, and named after the school's mascot. Gopher is a menu-driven interface that allows a user to browse for text information served off of various gopher servers.
+=> gopher://gopherpedia.com:70/1/about some information about gopher (and gopherpedia) at gopherpedia, a Wikipedia mirror for the gohper protocol
+
+## Gemini
+Gemini is a new application-level internet protocol for the distribution of arbitrary files, with some special consideration for serving a lightweight hypertext format which facilitates linking between files.
+=> gemini://gemini.circumlunar.space/ more official resources about gemini
+And actually, the document you are seeing here is written in Gemini's text format. You can take a look at this page in the sources in src/about/help.gmi !
+
+## What do you mean "sources"?
+ncgopher is free (libre) and open source software licensed under the "2-clause BSD" or "FreeBSD" license. The FreeBSD license is classified by the Free Software Foundation as a "free software license". The source code is versioned in a git repository available through GitHub. It is written in the Rust programming language.
+=> https://github.com/jansc/ncgopher
+Copyright © 2020, Jan Schreiber. Parts of the status bar implementation are Copyright © 2019, Henrik Friedrichsen.

--- a/src/about/sites.gmi
+++ b/src/about/sites.gmi
@@ -1,0 +1,17 @@
+# some pointers
+Here are some sites you might find interesting for a start. Remember you can use the i key to inspect any selected link. The URL which is linked will then be shown in the status bar at the bottom.
+
+## gopher
+
+=> gopher://gopher.floodgap.com:70/7/v2/vs Floodgap, also hosting Veronica/2 search
+=> gopher://gopherpedia.com:70/ search Gopherpedia
+=> gopher://perso.pw:70/ search OpenBSD man pages
+=> gopher://me0w.net:70/ some nice services like pastebin, web search with searx etc.
+=> gopher://jan.bio:70/ Jan's Gopherhole with the NCGOPHER USER GUIDE and Gopher Movie Database
+
+## gemini
+
+=> gemini://gus.guru/search search with GUS
+=> gemini://houston.coder.town/search Search with Houston
+=> gemini://gemini.circumlunar.space/ more authoritative about Gemini (also has a list of known Gemini servers!)
+=> gemini://jan.bio Jan's gemini site

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -90,7 +90,7 @@ impl Controller {
             bookmarks: Arc::new(Mutex::new(Bookmarks::new())),
             certificates: Arc::new(Mutex::new(Certificates::new())),
             content: Arc::new(Mutex::new(String::new())),
-            current_url: Arc::new(Mutex::new(Url::parse("gopher://host.none").unwrap())),
+            current_url: Arc::new(Mutex::new(Url::parse("about:blank").unwrap())),
             last_request_id: Arc::new(Mutex::new(0)),
         };
         ncgopher.setup_ui();

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -473,10 +473,10 @@ impl Controller {
                                         url.clone(),
                                     ))
                                     .unwrap();
+                                tx_clone
+                                    .send(ControllerMessage::RedrawHistory)
+                                    .unwrap();
                             }
-                            tx_clone
-                                .send(ControllerMessage::RedrawHistory)
-                                .unwrap();
                         } else {
                             // Binary download
                             let f = File::create(local_filename.clone()).unwrap_or_else(

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -111,6 +111,7 @@ impl Controller {
                 .unwrap()
                 .send(UiMessage::AddToHistoryMenu(entry))?;
         }
+        // Add bookmarks to bookmark menu on startup
         info!("Adding existing bookmarks to menu");
         let entries = controller.bookmarks.lock().unwrap().get_bookmarks();
         for entry in entries {
@@ -124,7 +125,7 @@ impl Controller {
                 .unwrap()
                 .send(UiMessage::AddToBookmarkMenu(entry))?;
         }
-        // Add bookmarks to bookmark menu on startup
+        // open initial page
         ncgopher.open_url(url, true, 0);
         info!("Controller::new() done");
         Ok(controller)

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -545,6 +545,14 @@ impl Controller {
                 | Some('6') // CLIENT CERTIFICATE
                 => {
                     if check(buf.chars().nth(1)) {
+                        // reset content and set current URL for retrying
+                        tx_clone
+                            .send(ControllerMessage::SetGeminiContent(
+                                url,
+                                GeminiType::Text,
+                                String::new(),
+                                0,
+                            )).unwrap();
                         tx_clone
                             .send(ControllerMessage::ShowMessage(format!(
                                 "Gemini error: {}",

--- a/src/gophermap.rs
+++ b/src/gophermap.rs
@@ -28,9 +28,9 @@ impl GopherMapEntry {
                 item_type: ItemType::Inline,
                 name: "".to_string(),
                 selector: "/".to_string(),
-                host: "fixme".to_string(),
+                host: "about:blank".to_string(),
                 port: 70,
-                url: Url::parse("gopher://fixme:70").unwrap(),
+                url: Url::parse("about:blank").unwrap(),
             });
         }
         if l.len() <= 3 {
@@ -42,7 +42,7 @@ impl GopherMapEntry {
         }
         let ch = l[0].chars().next().unwrap();
         let item_type = ItemType::decode(ch);
-        let name = l[0][1..].to_string();
+        let name = l[0][ch.len_utf8()..].to_string();
         let selector = l[1].to_string();
         let host = l[2].to_string();
         // Parse port, ignore invalid values
@@ -50,10 +50,10 @@ impl GopherMapEntry {
         let mut path = selector.clone();
         path.insert(0, ch);
 
-        let mut url = Url::parse("gopher://fixme:70").unwrap();
+        let mut url = Url::parse("gopher://example.com").unwrap();
         if item_type == ItemType::Telnet {
             // Telnet URLs have no selector
-            url = Url::parse("telnet://fixme:70").unwrap();
+            url.set_scheme("telnet").unwrap();
             if !host.is_empty() {
                 url.set_host(Some(host.as_str())).unwrap();
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,11 +128,9 @@ fn main() {
     let theme = SETTINGS.read().unwrap().get_str("theme").unwrap();
     app.load_toml(SETTINGS.read().unwrap().get_theme_by_name(theme))
         .unwrap();
-    let controller = Controller::new(app, homepage);
-    match controller {
-        Ok(mut controller) => controller.run(),
-        Err(e) => println!("Error: {}", e),
-    };
+    Controller::new(app, homepage)
+        .expect("could not create controller")
+        .run();
     print!("\x1B[?1002l");
     stdout().flush().expect("could not flush stdout");
     pancurses::endwin();

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ fn main() {
                     .read()
                     .unwrap()
                     .get_str("homepage")
-                    .expect("Could not find homepage in config")
+                    .unwrap() // there is a default in Settings, so this will never fail
                     .as_str(),
             )
             .expect("Invalid URL for configured homepage")

--- a/src/ncgopher.rs
+++ b/src/ncgopher.rs
@@ -609,6 +609,17 @@ impl NcGopher {
     /// Show an internal page from the "about" URL scheme
     /// as defined in RFC 6694.
     pub fn open_about(&mut self, mut url: Url) {
+        // FIXME if the first page is an about page, ncgopher will crash if we
+        // do not set a message and select the gemini_content view here because
+        // the gemini_content view will not be correctly resized when we get to
+        // putting in the content, probably because reading from memory is faster
+        // than a network request?
+        self.set_message("Preparing internal page...");
+        let mut app = self.app.write().unwrap();
+        app.call_on_name("main", |v: &mut ui::layout::Layout| {
+            v.set_view("gemini_content");
+        });
+
         let content = match url.path() {
             "blank" => String::new(),
             "help" => include_str!("about/help.gmi").into(),

--- a/src/ncgopher.rs
+++ b/src/ncgopher.rs
@@ -454,111 +454,22 @@ impl NcGopher {
                 .delimiter(),
         );
         menubar.add_subtree(
-            "Search",
-            MenuTree::new()
-                .leaf("Veronica/2...", |app| {
-                    let url = Url::parse("gopher://gopher.floodgap.com:70/7/v2/vs").unwrap();
-                    app.with_user_data(|userdata: &mut UserData| {
-                        userdata
-                            .ui_tx
-                            .read()
-                            .unwrap()
-                            .send(UiMessage::ShowSearchDialog(url))
-                            .unwrap()
-                    });
-                })
-                .leaf("Gopherpedia...", |app| {
-                    let url = Url::parse("gopher://gopherpedia.com:70/7/lookup").unwrap();
-                    app.with_user_data(|userdata: &mut UserData| {
-                        userdata
-                            .ui_tx
-                            .read()
-                            .unwrap()
-                            .send(UiMessage::ShowSearchDialog(url))
-                            .unwrap()
-                    });
-                })
-                .leaf("Gopher Movie Database...", |app| {
-                    let url = Url::parse("gopher://jan.bio:70/7/cgi-bin/gmdb.py").unwrap();
-                    app.with_user_data(|userdata: &mut UserData| {
-                        userdata
-                            .ui_tx
-                            .read()
-                            .unwrap()
-                            .send(UiMessage::ShowSearchDialog(url))
-                            .unwrap()
-                    });
-                })
-                .leaf("OpenBSD man pages...", |app| {
-                    let url = Url::parse("gopher://perso.pw:70/7/man.dcgi").unwrap();
-                    app.with_user_data(|userdata: &mut UserData| {
-                        userdata
-                            .ui_tx
-                            .read()
-                            .unwrap()
-                            .send(UiMessage::ShowSearchDialog(url))
-                            .unwrap()
-                    });
-                })
-                .leaf("searx search...", |app| {
-                    let url = Url::parse("gopher://me0w.net:70/7/searx.dcgi").unwrap();
-                    app.with_user_data(|userdata: &mut UserData| {
-                        userdata
-                            .ui_tx
-                            .read()
-                            .unwrap()
-                            .send(UiMessage::ShowSearchDialog(url))
-                            .unwrap()
-                    });
-                })
-                .leaf("[gemini] GUS...", |app| {
-                    let url = Url::parse("gemini://gus.guru/search").unwrap();
-                    app.with_user_data(|userdata: &mut UserData| {
-                        userdata
-                            .ui_tx
-                            .read()
-                            .unwrap()
-                            .send(UiMessage::OpenGeminiQueryDialog(
-                                url,
-                                "Enter query".to_string(),
-                                false,
-                            ))
-                            .unwrap()
-                    });
-                })
-                .leaf("[gemini] Houston...", |app| {
-                    let url = Url::parse("gemini://houston.coder.town/search").unwrap();
-                    app.with_user_data(|userdata: &mut UserData| {
-                        userdata
-                            .ui_tx
-                            .read()
-                            .unwrap()
-                            .send(UiMessage::OpenGeminiQueryDialog(
-                                url,
-                                "Enter query".to_string(),
-                                false,
-                            ))
-                            .unwrap()
-                    });
-                }),
-        );
-        menubar.add_subtree(
             "Help",
             MenuTree::new()
                 .subtree(
                     "Help",
                     MenuTree::new()
-                        .leaf("General", |s| {
+                        .leaf("Keys", |s| {
                             s.add_layer(Dialog::info(include_str!("help.txt")))
                         })
-                        .leaf("Online", |app| {
+                        .leaf("Extended", |app| {
                             app.with_user_data(|userdata: &mut UserData| {
                                 userdata
                                     .ui_tx
                                     .write()
                                     .unwrap()
                                     .send(UiMessage::OpenUrl(
-                                        Url::parse("gopher://jan.bio/1/ncgopher/").unwrap(),
+                                        Url::parse("about:help").unwrap(),
                                         false,
                                         0,
                                     ))
@@ -623,8 +534,10 @@ impl NcGopher {
         let content = match url.path() {
             "blank" => String::new(),
             "help" => include_str!("about/help.gmi").into(),
+            "sites" => include_str!("about/sites.gmi").into(),
+            "error" => "An error occured.".into(),
             _ => {
-                url.set_path("error");
+                url.set_path("blank");
                 "This about page does not exist".into()
             }
         };

--- a/src/ncgopher.rs
+++ b/src/ncgopher.rs
@@ -1228,16 +1228,10 @@ impl NcGopher {
         self.trigger();
     }
 
-    fn open_url_action(app: &mut Cursive, name: &str) {
+    fn open_url_action(app: &mut Cursive, url: &str) {
         app.pop_layer();
 
-        // Check that the Url has a scheme
-        let mut url = String::from(name);
-        if !url.contains(":") {
-            url.insert_str(0, "gopher://");
-        };
-
-        match Url::parse(&url) {
+        match Url::parse(url) {
             Ok(url) => app.with_user_data(|userdata: &mut UserData| {
                 userdata
                     .ui_tx

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -72,9 +72,7 @@ impl Settings {
                 .set_default("download_path", dl_dir.to_str())?;
         }
 
-        settings
-            .config
-            .set_default("homepage", "gopher://jan.bio:70/1/ncgopher/")?;
+        settings.config.set_default("homepage", "about:help")?;
         settings.config.set_default("debug", false)?;
         settings.config.set_default("theme", "lightmode")?;
         settings.config.set_default("html_command", "")?;


### PR DESCRIPTION
Resolves #25.

This removes URLs that have been hard coded in Rust code. Instead these URLs are now shown on internal pages accessible through the `about:` scheme. Consequently the complete search menu entry has been removed.
The internal sites use the existing code for displaying Gemini sites. Instead of getting content from a server, files from `src/about` are compiled into the binary via the `include_str!` macro.
Additionally things like `host.none` have been removed in favour of `about:blank`.
The initial home page (i.e. if not configured yet) is set to the internal `about:help` page to welcome new users and give some hopefully helpful information to start.

There is also a small usability improvement: The current URL would not correctly be set when a Gemini request failed so the refresh key could not be used for retrying the same page. This is now possible.