### PR TITLE
allow relative gemini redirects

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -526,7 +526,8 @@ impl Controller {
                     } else if !check(other) {
                         return;
                     }
-                    match Url::parse(&meta) {
+                    // redirect might be relative
+                    match url.join(&meta) {
                         Ok(url) => {
                             // FIXME: Try to parse url, check scheme
                             tx_clone.send(ControllerMessage::FetchGeminiUrl(url,true,0)).unwrap();


### PR DESCRIPTION
cf. https://lists.orbitalfox.eu/archives/gemini/2021/004959.html

Indeed, the Gemini specification states:
> ### 3.2.3 3x (REDIRECT)
> [...] The URL may be absolute or relative. [...]