### PR TITLE
handle incorrect gemini links gracefully

### DIFF
--- a/src/url_tools.rs
+++ b/src/url_tools.rs
@@ -54,9 +54,8 @@ pub fn human_readable_url(url: &Url) -> String {
             // the domain and the path will be percent encoded
             // it is easiest to do it all at once
             percent_encoding::percent_decode_str(url.as_str())
-                .decode_utf8()
-                .unwrap()
-                .to_string()
+                .decode_utf8_lossy()
+                .into_owned()
         }
     }
 }


### PR DESCRIPTION
Incorrect Gemini links caused panics before, but it is better for UX to handle these gracefully. Gemini-Links with invalid URLs are displayed like this:
```text
?URL?  This is an invalid URL, ncgopher will display it after the content: ?URL? gemini://:1965
```