### PR TITLE
Fix crash when dark mode is enabled

### DIFF
--- a/src/themes/darkmode.toml
+++ b/src/themes/darkmode.toml
@@ -21,7 +21,7 @@ borders = "simple" # Alternatives are "none" and "outset"
 	# An array with a single value has the same effect as a simple value.
 	primary   = "blue"
 	#secondary = "#EEEEEE"
-	#tertiary  = "#252521"
+	tertiary  = "#252521"
 
 	# Hex values can use lower or uppercase.
 	# (base color MUST be lowercase)


### PR DESCRIPTION
After enabling dark mode in the config, I noticed that ncgopher began silently exiting on startup with an error exit code.
If I manually commented out the `theme` setting in `config.toml` then it resumed launching successfully again, but the actual cause of the problem was a mystery.

I eventually discovered the `--debug` argument and found the following stacktrace in the resulting log file (would it make sense to emit panics like this to stderr as well so that they're easy to find?):
```
[...]
2022-02-11 08:25:33.474973638 +13:00 [INFO ] Controller::new() done
2022-02-11 08:25:33.518698662 +13:00 [ERROR] panicked at 'attempt to calculate the remainder with a divisor of zero', /home/nick/.cargo/registry/src/github.com-1ecc6299db9ec823/cursive-0.16.3/src/backends/curses/mod.rs:97:43
   0: ncgopher::main::{{closure}}
   1: std::panicking::rust_panic_with_hook
             at /rustc/1.58.1/library/std/src/panicking.rs:610:17
   2: std::panicking::begin_panic_handler::{{closure}}
             at /rustc/1.58.1/library/std/src/panicking.rs:500:13
   3: std::sys_common::backtrace::__rust_end_short_backtrace
             at /rustc/1.58.1/library/std/src/sys_common/backtrace.rs:139:18
   4: rust_begin_unwind
             at /rustc/1.58.1/library/std/src/panicking.rs:498:5
   5: core::panicking::panic_fmt
             at /rustc/1.58.1/library/core/src/panicking.rs:107:14
   6: core::panicking::panic
             at /rustc/1.58.1/library/core/src/panicking.rs:48:5
   7: cursive::backends::curses::find_closest
   8: cursive::backends::curses::pan::Backend::get_or_create
   9: <cursive::backends::curses::pan::Backend as cursive_core::backend::Backend>::set_color
  10: <ncgopher::ui::statusbar::StatusBar as cursive_core::view::view_trait::View>::draw
  11: cursive_core::view::view_wrapper::<impl cursive_core::view::view_trait::View for T>::draw
  12: <ncgopher::ui::layout::Layout as cursive_core::view::view_trait::View>::draw
  13: cursive_core::view::view_wrapper::<impl cursive_core::view::view_trait::View for T>::draw
  14: cursive_core::printer::Printer::with_color
  15: cursive_core::view::view_wrapper::<impl cursive_core::view::view_trait::View for T>::draw
  16: cursive_core::cursive::Cursive::draw
  17: cursive_core::cursive_run::CursiveRunner<C>::refresh
  18: cursive_core::cursive_run::CursiveRunner<C>::run
  19: cursive::cursive_runnable::CursiveRunnable::run
  20: ncgopher::main
  21: std::sys_common::backtrace::__rust_begin_short_backtrace
  22: std::rt::lang_start::{{closure}}
  23: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
             at /rustc/1.58.1/library/core/src/ops/function.rs:259:13
      std::panicking::try::do_call
             at /rustc/1.58.1/library/std/src/panicking.rs:406:40
      std::panicking::try
             at /rustc/1.58.1/library/std/src/panicking.rs:370:19
      std::panic::catch_unwind
             at /rustc/1.58.1/library/std/src/panic.rs:133:14
      std::rt::lang_start_internal::{{closure}}
             at /rustc/1.58.1/library/std/src/rt.rs:128:48
      std::panicking::try::do_call
             at /rustc/1.58.1/library/std/src/panicking.rs:406:40
      std::panicking::try
             at /rustc/1.58.1/library/std/src/panicking.rs:370:19
      std::panic::catch_unwind
             at /rustc/1.58.1/library/std/src/panic.rs:133:14
      std::rt::lang_start_internal
             at /rustc/1.58.1/library/std/src/rt.rs:128:20
  24: main
  25: __libc_start_main
  26: _start
```

After some trial and error with darkmode.toml, I found that uncommenting the `tertiary` color specifically fixed the crash.
The `tertiary` color seems to be used in `statusbar.rs`? FWIW I didn't see any mention of `secondary` in the code meanwhile.