### PR TITLE
add openbsd instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ you will most likely be able to tell what is missing.
 ### Arch-based Linux
 
     sudo pacman -S base-devel pkg-config openssl ncurses sqlite
+
+### OpenBSD
+
+    doas pkg_add sqlite3 rust
 ---
 
 If you know how to install the listed dependencies on your operating system and it is


### PR DESCRIPTION
pretty sure everything except sqlite3 and rust comes with OpenBSD. I already had sqlite3 installed so I just installed rust and ran cargo. ncgopher worked just fine on my first try with some gemini site my friend sent me, and that's all I really needed it for. cool project, I'll keep it on my laptop in case my friend sends me more gemini links.