### PR TITLE
Add keybinding support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,13 +35,13 @@ Tells me the problem that you have found, and the pull request shows me the acti
 
 * There are no spelling mistakes
 * It reads well
-* For english language contributions: Has a good score on [Grammarly](grammarly.com) or [Hemingway App](http://www.hemingwayapp.com/)
+* For English language contributions: Has a good score on [Grammarly](grammarly.com) or [Hemingway App](http://www.hemingwayapp.com/)
 
 ### Does it move this repository closer to my vision for the repository
 
 The aim of this repository is:
 
-* To provide a termina-based client for the slow web.
+* To provide a terminal-based client for the slow web.
 * Make textual information on gopher and gemini easily accessible to users.
 * Foster a culture of respect and gratitude in the open source community.
 

--- a/README.md
+++ b/README.md
@@ -105,8 +105,9 @@ To install the latest development version:
 
 ## Key bindings
 
-During alpha, the keybindings are not configurable and many operations
-are still not implemented.
+During alpha, many operations are still not implemented. Key bindings can be
+changed by adding a `keybindings` section in your `config.toml`, if you want to
+change them from the defaults below:
 
 | Key        | Command                        |
 | :--------- | :----------------------------- |
@@ -129,6 +130,27 @@ are still not implemented.
 | /          | Search in text                 |
 | n          | Move to next search result     |
 | N          | Move to previous search result |
+
+Here is an example `config.toml` with all the keybindings defined:
+```toml
+[keybindings]
+open_new_url = 'o'
+edit_current_url = 'e'
+navigate_back = 'h'
+close = 'q'
+save_page = 's'
+reload_page = 'r'
+show_link = 'i'
+add_bookmark = 'b'
+next_link = 'l'
+previous_link = 'L'
+move_down = 'j'
+move_up = 'k'
+search_in_text = '/'
+next_search_result = 'n'
+previous_search_result = 'N'
+show_help = '?'
+```
 
 ## Mouse support
 

--- a/src/about/help.gmi
+++ b/src/about/help.gmi
@@ -31,7 +31,7 @@ Welcome to ncgopher, an ncurses client for gemini, gopher and finger. You can us
 # What is this?
 ncgopher is a browser for the gemini and the gopher protocols, sometimes also collectively known as the "small internet".
 
-=> about:sites See some pages to start of from.
+=> about:sites See some pages to start off.
 
 ## Gopher
 Gopher was deveolped in 1991 at the University of Minnesota, and named after the school's mascot. Gopher is a menu-driven interface that allows a user to browse for text information served off of various gopher servers.

--- a/src/help.txt
+++ b/src/help.txt
@@ -23,3 +23,4 @@
 | ?          | Display this help text         |
 |------------+--------------------------------|
 
+TODO: Generate this from the keybindings

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -16,6 +16,85 @@ pub struct Settings {
     themes: HashMap<String, String>,
 }
 
+// TODO: Split this into another file, I think.
+fn default_open_new_url() -> char              { 'g' }
+fn default_edit_current_url() -> char          { 'G' }
+fn default_navigate_back() -> char             { 'b' }
+fn default_close() -> char                     { 'q' }
+fn default_save_page() -> char                 { 's' }
+fn default_reload_page() -> char               { 'r' }
+fn default_show_link() -> char                 { 'i' }
+fn default_add_bookmark() -> char              { 'a' }
+fn default_next_link() -> char                 { 'l' }
+fn default_previous_link() -> char             { 'L' }
+fn default_move_down() -> char                 { 'j' }
+fn default_move_up() -> char                   { 'k' }
+fn default_search_in_text() -> char            { '/' }
+fn default_next_search_result() -> char        { 'n' }
+fn default_previous_search_result() -> char    { 'N' }
+fn default_show_help() -> char                 { '?' }
+
+pub fn default_keybindings() -> KeyBindings {
+    KeyBindings {
+        open_new_url: default_open_new_url(),
+        edit_current_url: default_edit_current_url(),
+        navigate_back: default_navigate_back(),
+        close: default_close(),
+        save_page: default_save_page(),
+        reload_page: default_reload_page(),
+        show_link: default_show_link(),
+        add_bookmark: default_add_bookmark(),
+        next_link: default_next_link(),
+        previous_link: default_previous_link(),
+        move_up: default_move_up(),
+        move_down: default_move_down(),
+        search_in_text: default_search_in_text(),
+        next_search_result: default_next_search_result(),
+        previous_search_result: default_previous_search_result(),
+        show_help: default_show_help(),
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(default = "default_keybindings")]
+pub struct KeyBindings {
+    #[serde(default = "default_open_new_url", deserialize_with = "ok_or_default")]
+    pub open_new_url: char,
+
+    #[serde(default = "default_edit_current_url", deserialize_with = "ok_or_default")]
+    pub edit_current_url: char,
+
+    #[serde(default = "default_navigate_back", deserialize_with = "ok_or_default")]
+    pub navigate_back: char,
+
+    #[serde(default = "default_close", deserialize_with = "ok_or_default")]
+    pub close: char,
+    #[serde(default = "default_save_page", deserialize_with = "ok_or_default")]
+    pub save_page: char,
+    #[serde(default = "default_reload_page", deserialize_with = "ok_or_default")]
+    pub reload_page: char,
+    #[serde(default = "default_show_link", deserialize_with = "ok_or_default")]
+    pub show_link: char,
+    #[serde(default = "default_add_bookmark", deserialize_with = "ok_or_default")]
+    pub add_bookmark: char,
+    #[serde(default = "default_next_link", deserialize_with = "ok_or_default")]
+    pub next_link: char,
+    #[serde(default = "default_previous_link", deserialize_with = "ok_or_default")]
+    pub previous_link: char,
+    #[serde(default = "default_move_down", deserialize_with = "ok_or_default")]
+    pub move_down: char,
+    #[serde(default = "default_move_up", deserialize_with = "ok_or_default")]
+    pub move_up: char,
+    #[serde(default = "default_search_in_text", deserialize_with = "ok_or_default")]
+    pub search_in_text: char,
+    #[serde(default = "default_next_search_result", deserialize_with = "ok_or_default")]
+    pub next_search_result: char,
+    #[serde(default = "default_previous_search_result", deserialize_with = "ok_or_default")]
+    pub previous_search_result: char,
+    #[serde(default = "default_show_help", deserialize_with = "ok_or_default")]
+    pub show_help: char,
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct NewConfig {
     #[serde(default = "default_download_path", deserialize_with = "ok_or_default")]
@@ -44,6 +123,10 @@ pub struct NewConfig {
         deserialize_with = "ok_or_default"
     )]
     pub disable_identities: bool,
+
+    // Option<> supports older config files that don't have this.
+    pub keybindings: Option<KeyBindings>,
+
 }
 
 fn ok_or_default<'a, T, D>(deserializer: D) -> Result<T, D::Error>

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -16,7 +16,6 @@ pub struct Settings {
     themes: HashMap<String, String>,
 }
 
-// TODO: Split this into another file, I think.
 fn default_open_new_url() -> char              { 'g' }
 fn default_edit_current_url() -> char          { 'G' }
 fn default_navigate_back() -> char             { 'b' }
@@ -60,13 +59,10 @@ pub fn default_keybindings() -> KeyBindings {
 pub struct KeyBindings {
     #[serde(default = "default_open_new_url", deserialize_with = "ok_or_default")]
     pub open_new_url: char,
-
     #[serde(default = "default_edit_current_url", deserialize_with = "ok_or_default")]
     pub edit_current_url: char,
-
     #[serde(default = "default_navigate_back", deserialize_with = "ok_or_default")]
     pub navigate_back: char,
-
     #[serde(default = "default_close", deserialize_with = "ok_or_default")]
     pub close: char,
     #[serde(default = "default_save_page", deserialize_with = "ok_or_default")]


### PR DESCRIPTION
- Lets you define custom keybindings in the `config.toml` file.
- Generates help text based on what keybindings are active
- Keeps defaults the same for users accustomed to the old keybindings
- Updates the README to document how to change keybindings.